### PR TITLE
Fixed endianness conversion bug with zero-decimal tokens

### DIFF
--- a/src/NeoModules.RPC/Services/NeoNep5Service.cs
+++ b/src/NeoModules.RPC/Services/NeoNep5Service.cs
@@ -57,10 +57,9 @@ namespace NeoModules.RPC.Services
             if (result.State == "FAULT, BREAK")
                 throw new RpcResponseException(new RpcError(0, "RPC state response: FAULT, BREAK "));
 
-            var resultString = result.Stack[0].Value.ToString();
-            if (decimals.Equals(0)) return Convert.ToInt64(resultString, 16);
+            var totalSupplyBigInteger = new BigInteger(result.Stack[0].Value.ToString().HexStringToBytes());
+            if (decimals.Equals(0)) return (decimal) totalSupplyBigInteger;
 
-            var totalSupplyBigInteger = new BigInteger(resultString.HexStringToBytes());
             var totalSupply = Nep5Helper.CalculateDecimalFromBigInteger(totalSupplyBigInteger, decimals);
 
             return totalSupply;
@@ -83,10 +82,9 @@ namespace NeoModules.RPC.Services
             if (result.State == "FAULT, BREAK")
                 throw new RpcResponseException(new RpcError(0, "RPC state response: FAULT, BREAK "));
 
-            var resultString = result.Stack[0].Value.ToString();
-            if (decimals.Equals(0)) return Convert.ToInt64(resultString, 16);
+            var balanceBigInteger = new BigInteger(result.Stack[0].Value.ToString().HexStringToBytes());
+            if (decimals.Equals(0)) return (decimal) balanceBigInteger;
 
-            var balanceBigInteger = new BigInteger(resultString.HexStringToBytes());
             var balance =  Nep5Helper.CalculateDecimalFromBigInteger(balanceBigInteger, decimals);
 
             return balance;


### PR DESCRIPTION
While testing NeoModules I discovered that the balances for RHT (a token with zero decimal precision) were being returned incorrectly, and, in the case of a user with a zero balance, an exception was being thrown.

I traced the issue to the built-in`Convert.ToInt64` call in the case of zero-decimal tokens. First, it doesn't seem able to deal with an empty value (which the Neo VM returns instead of zero in smart contract execution results) and throws an exception. Second, it seems (in my testing at least) to parse the hex string in big-endian order even on a little-endian system, leading to incorrect results.

I fixed both issues by unifying the parsing operation for all input `decimals` values using the `BigInteger` constructor on the hex string retrieved from the smart contract execution, and skipping the decimals calculation in the case that the function was called with a decimals argument of zero. This then gave the correct results, even in the case of a zero token balance.
