### PR TITLE
Issue 10 - Fix empty balance.AssetHash issue when outdated neo-scan is used

### DIFF
--- a/src/NeoModules.Rest/Services/NeoscanRestService.cs
+++ b/src/NeoModules.Rest/Services/NeoscanRestService.cs
@@ -34,6 +34,11 @@ namespace NeoModules.Rest.Services
 
         private readonly HttpClient _restClient;
 
+        private static Dictionary<string, string> assetsDict = new Dictionary<string, string>(){
+            { "NEO", "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b"},
+            { "GAS", "602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"}
+        };
+
         public NeoScanRestService(NeoScanNet net)
         {
             _restClient = net == NeoScanNet.MainNet
@@ -53,7 +58,15 @@ namespace NeoModules.Rest.Services
             var composedUrl = Utils.ComposeUrl(getBalanceUrl, address);
             var result = await _restClient.GetAsync(composedUrl);
             var data = await result.Content.ReadAsStringAsync();
-            return AddressBalance.FromJson(data);
+
+            var addressBalance = AddressBalance.FromJson(data);
+
+            foreach (var balance in addressBalance.Balance)
+            {
+                if (string.IsNullOrWhiteSpace(balance.AssetHash))
+                    balance.AssetHash = assetsDict[balance.Asset];
+            }
+            return addressBalance;
         }
 
         public async Task<Claimable> GetClaimableAsync(string address)


### PR DESCRIPTION
I used neo-scan docker recommended here: https://hub.docker.com/r/cityofzion/neo-privatenet. I can see the ticket 'Update NeoScan to latest release' on the neo-scan docker GitHub, so possibly it is not the latest version and that is the reason of issue. But I have not found better docker and I cannot use different code for my automated unit tests and for production environment. This is the official recommendation to debug with local privateNet, then test with testNet and after them move to mainNet. May be it is my end issues, but currently it is a deal stopper. And I believe it is a deal stopper not for me only. I currently cannot use NeoModules because of this failure. Suggested fix is similar with logic in neo-lux.